### PR TITLE
Corrected spelling error

### DIFF
--- a/version.php
+++ b/version.php
@@ -3,7 +3,7 @@
 defined('MOODLE_INTERNAL') || die;
 
 $plugin->version   = 2016063001;
-$plguin->component = 'mod_connectproxymodule';
+$plugin->component = 'mod_connectproxymodule';
 $plugin->requires  = 2014051200;
 $plugin->maturity  =  MATURITY_STABLE;
 $plugin->release   =  'v.2.7-r0.1';


### PR DESCRIPTION
Hi Henrik

It seems there was a tiny spelling error preventing installing the plugin into moodle 3.1
I have changed it to allow installing.

Best Regards
Kristian ITU-IT